### PR TITLE
feat: add support for China T-Union

### DIFF
--- a/src/Dedge.Cardidy/CardType.cs
+++ b/src/Dedge.Cardidy/CardType.cs
@@ -25,5 +25,7 @@ public enum CardType
     Visa,
 
     BankCard,
+
+    ChinaTUnion,
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/Dedge.Cardidy/Cardidy.cs
+++ b/src/Dedge.Cardidy/Cardidy.cs
@@ -31,6 +31,8 @@ public static class Cardidy
         new Visa(),
 
         new BankCard(),
+
+        new ChinaTUnion(),
     };
 
     private const int identificationNumberLength = 8;

--- a/src/Dedge.Cardidy/Model/ACard.cs
+++ b/src/Dedge.Cardidy/Model/ACard.cs
@@ -7,6 +7,7 @@ internal abstract record ACard : ICard
 {
     protected static readonly int[] Fifteen = { 15 };
     protected static readonly int[] Sixteen = { 16 };
+    protected static readonly int[] Nineteen = { 19 };
     protected static readonly int[] From12To19 = { 12, 13, 14, 15, 16, 17, 18, 19 };
     protected static readonly int[] From16To19 = { 16, 17, 18, 19 };
 

--- a/src/Dedge.Cardidy/Model/Cards.cs
+++ b/src/Dedge.Cardidy/Model/Cards.cs
@@ -69,3 +69,8 @@ internal record BankCard : ALuhnCard
 {
     public BankCard() : base(CardType.BankCard, new[] { new PaddedRange(5610), new PaddedRange(560221, 560225) }, Sixteen) { }
 }
+
+internal record ChinaTUnion : ALuhnCard
+{
+    public ChinaTUnion() : base(CardType.ChinaTUnion, new[] { new PaddedRange(31) }, Nineteen) { }
+}

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -119,4 +119,9 @@ public class IdentifyTests
     [TestCase("5602213166347852", ExpectedResult = CardType.BankCard)]
     [TestCase("5602253004948429", ExpectedResult = CardType.BankCard)]
     public CardType ShouldIdentifyAsBankCard(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true).First();
+
+    [TestCase("3104930400000001932", ExpectedResult = CardType.ChinaTUnion)]
+    [TestCase("3105071901000005001", ExpectedResult = CardType.ChinaTUnion)]
+    [TestCase("3104830500000000001", ExpectedResult = CardType.ChinaTUnion)]
+    public CardType ShouldIdentifyAsChinaTUnion(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true).First();
 }


### PR DESCRIPTION
Followed the step-by-step Contributing file, and tested with 3 different card numbers using the pattern on the Wikipedia page.

I needed to create a new global variable because this card use 19 numbers.

PR linked to issue #11 