### PR TITLE
feat(card): add support for RuPay

### DIFF
--- a/src/Dedge.Cardidy/CardType.cs
+++ b/src/Dedge.Cardidy/CardType.cs
@@ -28,5 +28,6 @@ public enum CardType
     BankCard,
     UkrCard,
     ChinaTUnion,
+    RuPay,
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/Dedge.Cardidy/Cardidy.cs
+++ b/src/Dedge.Cardidy/Cardidy.cs
@@ -33,6 +33,7 @@ public static class Cardidy
         new BankCard(),
         new UkrCard(),
         new ChinaTUnion(),
+        new RuPay(),
     };
 
     private const int identificationNumberLength = 8;

--- a/src/Dedge.Cardidy/Model/Cards.cs
+++ b/src/Dedge.Cardidy/Model/Cards.cs
@@ -79,3 +79,8 @@ internal record ChinaTUnion : ALuhnCard
 {
     public ChinaTUnion() : base(CardType.ChinaTUnion, 31, Nineteen) { }
 }
+
+internal record RuPay : ALuhnCard
+{
+    public RuPay() : base(CardType.RuPay, new[] { 60, 65, 81, 82, 353, 356, 508 }, Sixteen) { }
+}

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -90,8 +90,8 @@ public class IdentifyTests
     [TestCase("2204200000000000", ExpectedResult = CardType.Mir)]
     public CardType ShouldIdentifyAsMir(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false).First();
 
-    [TestCase("6011-773331987017", ExpectedResult = new[] { CardType.Discover })]
-    [TestCase("65-18958254583145", ExpectedResult = new[] { CardType.Discover })]
+    [TestCase("6011-773331987017", ExpectedResult = new[] { CardType.Discover, CardType.RuPay })]
+    [TestCase("65-18958254583145", ExpectedResult = new[] { CardType.Discover, CardType.RuPay })]
     [TestCase("622126-1230594033", ExpectedResult = new[] { CardType.Discover, CardType.UnionPay })]
     [TestCase("622225-1230594033", ExpectedResult = new[] { CardType.Discover, CardType.UnionPay })]
     [TestCase("622925-1230594033", ExpectedResult = new[] { CardType.Discover, CardType.UnionPay })]
@@ -110,9 +110,9 @@ public class IdentifyTests
     [TestCase("6500100000000001", true, ExpectedResult = new[] { CardType.Verve })]
     [TestCase("6500270000000000", true, ExpectedResult = new[] { CardType.Verve })]
     [TestCase("6500270000000000000", true, ExpectedResult = new[] { CardType.Verve })]
-    [TestCase("6500020000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover })]
-    [TestCase("6500100000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover })]
-    [TestCase("6500270000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover })]
+    [TestCase("6500020000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover, CardType.RuPay })]
+    [TestCase("6500100000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover, CardType.RuPay })]
+    [TestCase("6500270000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover, CardType.RuPay })]
     [TestCase("65002700000000000", false, ExpectedResult = new[] { CardType.Discover })]
     [TestCase("650027000000000000", false, ExpectedResult = new[] { CardType.Discover })]
     [TestCase("6500270000000000000", false, ExpectedResult = new[] { CardType.Verve, CardType.Discover })]
@@ -141,4 +141,14 @@ public class IdentifyTests
     [TestCase("3105071901000005001", ExpectedResult = CardType.ChinaTUnion)]
     [TestCase("3104830500000000001", ExpectedResult = CardType.ChinaTUnion)]
     public CardType ShouldIdentifyAsChinaTUnion(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true).First();
+
+    // note that: 65 is shared by both RuPay and Discover; 353 and 356 are part of JCB Card
+    [TestCase("6000123456789010", ExpectedResult = new[] { CardType.RuPay })]
+    [TestCase("6505071901000005", ExpectedResult = new[] { CardType.Discover, CardType.RuPay })]
+    [TestCase("8104830500000000", ExpectedResult = new[] { CardType.RuPay })]
+    [TestCase("8204930400000001", ExpectedResult = new[] { CardType.RuPay })]
+    [TestCase("3534930400000001", ExpectedResult = new[] { CardType.Jcb, CardType.RuPay })]
+    [TestCase("3564930400000001", ExpectedResult = new[] { CardType.Jcb, CardType.RuPay })]
+    [TestCase("5084830500000000", ExpectedResult = new[] { CardType.RuPay })]
+    public IEnumerable<CardType> ShouldIdentifyAsRuPay(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true);
 }


### PR DESCRIPTION
Was needed to add Rupay card into Discover and Verve tests, because they share some numbers at the start (60 and 65). In my tests, I added the Discover and Jcb enumerators too because of the same reason above.

Followed the step-by-step Contributing file, and tested with 7 different card numbers using the pattern on the Wikipedia page.

PR linked to issue #14 