### PR TITLE
Add support for InstaPayment

### DIFF
--- a/src/Dedge.Cardidy/CardType.cs
+++ b/src/Dedge.Cardidy/CardType.cs
@@ -1,4 +1,4 @@
-namespace Dedge;
+﻿namespace Dedge;
 
 /// <summary>
 /// Current supported CardType
@@ -30,6 +30,7 @@ public enum CardType
     ChinaTUnion,
     InterPayment,
     RuPay,
+    InstaPayment,
 
     LankaPay,
     Humo

--- a/src/Dedge.Cardidy/Cardidy.cs
+++ b/src/Dedge.Cardidy/Cardidy.cs
@@ -35,9 +35,10 @@ public static class Cardidy
         new ChinaTUnion(),
         new InterPayment(),
         new RuPay(),
-
+        new InstaPayment(),
+        
         new LankaPay(),
-        new Humo(),
+        new Humo()
     };
 
     private const int identificationNumberLength = 8;

--- a/src/Dedge.Cardidy/Model/Cards.cs
+++ b/src/Dedge.Cardidy/Model/Cards.cs
@@ -90,6 +90,11 @@ internal record RuPay : ALuhnCard
     public RuPay() : base(CardType.RuPay, new[] { 60, 65, 81, 82, 353, 356, 508 }, Sixteen) { }
 }
 
+internal record InstaPayment : ALuhnCard
+{
+    public InstaPayment() : base(CardType.InstaPayment, new [] { new PaddedRange(637, 639) }, Sixteen) { }
+}
+
 internal record LankaPay : ACard
 {
     public LankaPay() : base(CardType.LankaPay, 357111, Sixteen) { }

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -158,6 +158,15 @@ public class IdentifyTests
     [TestCase("5084830500000000", ExpectedResult = new[] { CardType.RuPay })]
     public IEnumerable<CardType> ShouldIdentifyAsRuPay(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true);
 
+    [TestCase("6378041128616666", ExpectedResult = CardType.InstaPayment)]
+    [TestCase("6370871259156324", ExpectedResult = CardType.InstaPayment)]
+    [TestCase("6379373029422806", ExpectedResult = CardType.InstaPayment)]
+    [TestCase("6384395716103251", ExpectedResult = CardType.InstaPayment)]
+    [TestCase("6381720515879954", ExpectedResult = CardType.InstaPayment)]
+    [TestCase("6398746976455613", ExpectedResult = CardType.InstaPayment)]
+    [TestCase("6384960368309025--", ExpectedResult = CardType.InstaPayment)]
+    public CardType ShouldIdentifyAsInstaPayment(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: true, ignoreNoise: true).First();
+
     [TestCase("9860123456789876", ExpectedResult = CardType.Humo)]
     [TestCase("9860010102205720", ExpectedResult = CardType.Humo)]
     public CardType ShouldIdentifyAsHumo(string cardNumber) => Cardidy.Identify(cardNumber).First();


### PR DESCRIPTION
PR for issue #16 

I have added support for InstaPayment cards. I tried to make Luhn algorithm work adding the checksum digit and trying with `useCheck = true`, but got no luck. In any case, I think the basic support works.