### PR TITLE
Allow noise in strict mode

### DIFF
--- a/src/Dedge.Cardidy/Cardidy.cs
+++ b/src/Dedge.Cardidy/Cardidy.cs
@@ -80,7 +80,7 @@ public static class Cardidy
 
         var digits = numbers.Select(c => int.TryParse(c.ToString(), out var i) ? i : 0).ToList();
         var identificationNumber = digits.Take(identificationNumberLength).ToNumber().PadRight(identificationNumberLength, 0);
-        var isStrict = validateLength && !ignoreNoise && !handleAnonymization;
+        var isStrict = validateLength && !handleAnonymization;
         return knownCards
             .Where(knownCard => knownCard.Prefixes
                 .Any(prefix => prefix.Contains(identificationNumber)


### PR DESCRIPTION
PR for #43 

I have applied the change as described, but I have tried my test for InstaPayment cards (see #16) and I discovered that the problem seems to be related to `validateLength`, because it expects a card number 16 characters long and with the checksum it has 17 (if I understand this right). This is the test I am trying to get working:

```
[TestCase("63838409125286459", true, ExpectedResult = CardType.InstaPayment)]
    [TestCase("6378677194942262", false, ExpectedResult = CardType.InstaPayment)]
    [TestCase("6381541706661937", false, ExpectedResult = CardType.InstaPayment)]
    [TestCase("6390040771959329", false, ExpectedResult = CardType.InstaPayment)]
    [TestCase("6397433525160793", false, ExpectedResult = CardType.InstaPayment)]
    [TestCase("6383193232105329", false, ExpectedResult = CardType.InstaPayment)]
    [TestCase("6383193232105329--", false, ExpectedResult = CardType.InstaPayment)]
    public CardType ShouldIdentifyAsInstaPayment(string cardNumber, bool useCheck) => Cardidy.Identify(cardNumber, useCheck: useCheck, ignoreNoise: true).First();
```

The first one fails because it is 17 characters long.

UPDATE: Ok, I found that the problem was the InstaPayment card number generator I was using. I have changed all numbers using a new one and Luhn check works perfectly with this fix.