### PR TITLE
refactor: use a tuple to initialize properties in the constructor

### DIFF
--- a/src/Dedge.Cardidy/Model/ACard.cs
+++ b/src/Dedge.Cardidy/Model/ACard.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Dedge.Model;
@@ -12,7 +12,7 @@ internal abstract record ACard : ICard
     protected static readonly int[] From16To19 = { 16, 17, 18, 19 };
 
     internal ACard(CardType name, IEnumerable<PaddedRange> prefixes, IEnumerable<int>
-        lengths) => (Prefixes, Lengths, Name) = (prefixes, lengths, name);
+        lengths) => (Name, Prefixes, Lengths) = (name, prefixes, lengths);
 
     internal ACard(CardType name, IEnumerable<int> prefixes, IEnumerable<int>
         lengths) : this(name, prefixes.Select(x => new PaddedRange(x)), lengths)

--- a/src/Dedge.Cardidy/Model/ACard.cs
+++ b/src/Dedge.Cardidy/Model/ACard.cs
@@ -12,12 +12,7 @@ internal abstract record ACard : ICard
     protected static readonly int[] From16To19 = { 16, 17, 18, 19 };
 
     internal ACard(CardType name, IEnumerable<PaddedRange> prefixes, IEnumerable<int>
-        lengths)
-    {
-        Prefixes = prefixes;
-        Lengths = lengths;
-        Name = name;
-    }
+        lengths) => (Prefixes, Lengths, Name) = (prefixes, lengths, name);
 
     internal ACard(CardType name, IEnumerable<int> prefixes, IEnumerable<int>
         lengths) : this(name, prefixes.Select(x => new PaddedRange(x)), lengths)


### PR DESCRIPTION
That is just a syntactic sugar:

```
public Point(int x, int y, int z)
{
    X = x;
    Y = y;
    Z = z;
}
```

can be written as:

```
public Point(int x, int y, int z) => (X, Y, Z) = (x, y, z);
```

The compilation result are the same.

source:
* [Using Tuples in C# to Initialize Properties in the Constructor and to Deconstruct Your Object](https://www.thomasclaudiushuber.com/2021/03/25/csharp-using-tuples-to-initialize-properties/)
* [C# 10 new feature CallerArgumentExpression, argument check and more](https://weblogs.asp.net/dixin/csharp-10-new-feature-callerargumentexpression-argument-check-and-more)