### PR TITLE
ci(build): bump to net6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,15 +24,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-2022, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
-          include-prerelease: True
+          dotnet-version: 6.0.100
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -72,8 +71,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
-          include-prerelease: True
+          dotnet-version: 6.0.100
       - name: Create Release NuGet package
         run: |
           arrTag=(${GITHUB_REF//\// })


### PR DESCRIPTION
Move from 6.0rc to 6.0. We dont need to pin `windows-2022` anymore.