### PR TITLE
refactor(diners): rename Diners Intl to Diners

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ let main _ =
     0
 ```
 
+## Note
+
+The library mostly follows the Wikipedia's page: [Payment card number](https://en.wikipedia.org/wiki/Payment_card_number#Issuer_identification_number_(IIN)). On Cardidy, we made some modifications though:
+
+- Diners Club International is known as Diners Club
+
 ## License
 
 [MIT](https://raw.githubusercontent.com/d-edge/cardidy/main/LICENSE)

--- a/src/Dedge.Cardidy/CardType.cs
+++ b/src/Dedge.Cardidy/CardType.cs
@@ -11,7 +11,6 @@ public enum CardType
     AmericanExpress,
     Uatp,
     UnionPay,
-    DinersClub,
     Jcb,
     Mir,
 

--- a/src/Dedge.Cardidy/CardType.cs
+++ b/src/Dedge.Cardidy/CardType.cs
@@ -1,4 +1,4 @@
-namespace Dedge;
+﻿namespace Dedge;
 
 /// <summary>
 /// Current supported CardType
@@ -38,7 +38,7 @@ public enum CardType
     Humo,
     UzCard,
     Dankort,
-    DinersClubInternational,
+    DinersClub,
     DinersClubUsAndCanada
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/Dedge.Cardidy/Cardidy.cs
+++ b/src/Dedge.Cardidy/Cardidy.cs
@@ -44,7 +44,7 @@ public static class Cardidy
         new Humo(),
         new Dankort(),
         new UzCard(),
-        new DinersClubInternational(),
+        new DinersClub(),
         new DinersClubUsAndCanada()
     };
 

--- a/src/Dedge.Cardidy/Model/Cards.cs
+++ b/src/Dedge.Cardidy/Model/Cards.cs
@@ -125,9 +125,9 @@ internal record UzCard : ACard
     public UzCard() : base(CardType.UzCard, 8600, Sixteen) { }
 }
 
-internal record DinersClubInternational : ALuhnCard
+internal record DinersClub : ALuhnCard
 {
-    public DinersClubInternational() : base(CardType.DinersClubInternational, 36, From14To19) { }
+    public DinersClub() : base(CardType.DinersClub, 36, From14To19) { }
 }
 
 internal record DinersClubUsAndCanada : ALuhnCard

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -1,4 +1,4 @@
-using Dedge;
+﻿using Dedge;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
@@ -193,13 +193,13 @@ public class IdentifyTests
     [TestCase("8600002200510732", ExpectedResult = CardType.UzCard)]
     public CardType ShouldIdentifyAsUzCard(string cardNumber) => Cardidy.Identify(cardNumber).First();
 
-    [TestCase("36148411266187", ExpectedResult = CardType.DinersClubInternational)]
-    [TestCase("361633833419261", ExpectedResult = CardType.DinersClubInternational)]
-    [TestCase("3616338334560012", ExpectedResult = CardType.DinersClubInternational)]
-    [TestCase("36203293000640011", ExpectedResult = CardType.DinersClubInternational)]
-    [TestCase("364540458679150018", ExpectedResult = CardType.DinersClubInternational)]
-    [TestCase("3634948501962945908", ExpectedResult = CardType.DinersClubInternational)]
-    public CardType ShouldIdentifyAsDinersClubInternational(string cardNumber) => Cardidy.Identify(cardNumber).First();
+    [TestCase("36148411266187", ExpectedResult = CardType.DinersClub)]
+    [TestCase("361633833419261", ExpectedResult = CardType.DinersClub)]
+    [TestCase("3616338334560012", ExpectedResult = CardType.DinersClub)]
+    [TestCase("36203293000640011", ExpectedResult = CardType.DinersClub)]
+    [TestCase("364540458679150018", ExpectedResult = CardType.DinersClub)]
+    [TestCase("3634948501962945908", ExpectedResult = CardType.DinersClub)]
+    public CardType ShouldIdentifyAsDinersClub(string cardNumber) => Cardidy.Identify(cardNumber).First();
 
     [TestCase("5495996449417153", ExpectedResult = new[] { CardType.MasterCard, CardType.DinersClubUsAndCanada })]
     [TestCase("5422292357387168", ExpectedResult = new[] { CardType.MasterCard, CardType.DinersClubUsAndCanada })]


### PR DESCRIPTION
Hello,

Following an exchange with @4gq and @fighou, we decided to rename Diners Club International into Diners Club. We are aiming for simplification and terseness here. Since this is a small variation from the Wikipedia page, a note was added to the README.

Cheers,