### PR TITLE
ci: add readme in nuget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,9 +38,25 @@ jobs:
         run: dotnet build -c Release --no-restore
       - name: Test
         run: dotnet test -c Release
+      - name: Strip HTML from README
+        uses: d-edge/strip-markdown-html@v0.1
+        with:
+          input-path: README.md
+          output-path: src/${{ env.PROJECT_NAME }}/README.md
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            arrTag=(${GITHUB_REF//\// })
+            VERSION="${arrTag[2]}"
+            echo Version: $VERSION
+            VERSION="${VERSION//v}"
+            echo Clean Version: $VERSION
+          else
+            VERSION=$GITHUB_RUN_ID
+            echo Non-release version: $VERSION
+          fi
+          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$VERSION src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2
@@ -72,14 +88,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.100
-      - name: Create Release NuGet package
-        run: |
-          arrTag=(${GITHUB_REF//\// })
-          VERSION="${arrTag[2]}"
-          echo Version: $VERSION
-          VERSION="${VERSION//v}"
-          echo Clean Version: $VERSION
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
+      - name: Download Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: nupkg
       - name: Push to GitHub Feed
         run: |
           for f in ./nupkg/*.nupkg

--- a/src/Dedge.Cardidy/Dedge.Cardidy.csproj
+++ b/src/Dedge.Cardidy/Dedge.Cardidy.csproj
@@ -34,6 +34,7 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 
 		<Nullable>enable</Nullable>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -41,17 +42,18 @@
 			<Pack>true</Pack>
 			<PackagePath>$(PackageIconUrl)</PackagePath>
 		</None>
+		<None Include="README.md" Pack="true" PackagePath="\"/>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Include="Cardidy.cs" />
-	  <Compile Include="CardType.cs" />
-	  <Compile Include="Extensions.cs" />
-	  <Compile Include="Model\ACard.cs" />
-	  <Compile Include="Model\ALuhnCard.cs" />
-	  <Compile Include="Model\Cards.cs" />
-	  <Compile Include="Model\ICard.cs" />
-	  <Compile Include="Model\PaddedRange.cs" />
+		<Compile Include="Cardidy.cs" />
+		<Compile Include="CardType.cs" />
+		<Compile Include="Extensions.cs" />
+		<Compile Include="Model\ACard.cs" />
+		<Compile Include="Model\ALuhnCard.cs" />
+		<Compile Include="Model\Cards.cs" />
+		<Compile Include="Model\ICard.cs" />
+		<Compile Include="Model\PaddedRange.cs" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Follow Diffract and Cardizer to include the readme into nuget.

here is the before/after for Cardizer:

![rd-in-nuget](https://user-images.githubusercontent.com/3449303/150395217-9b2613f8-1a13-45f4-99fa-51a82d6755d7.png)
