### PR TITLE
docs(github): fix typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/card-request.md
+++ b/.github/ISSUE_TEMPLATE/card-request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!-- Replace XXX with the new card -->
-<!--Fill the table as per the wiki link or any other valid soure-->
+<!--Fill the table as per the wiki link or any other valid source-->
 
 Hello,
 


### PR DESCRIPTION
Well "soure" should be "source"...