### PR TITLE
ci(net): install the latest patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.100
+          dotnet-version: 7.0
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -90,7 +90,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.100
+          dotnet-version: 7.0
       - name: Download Artifact
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0
+          dotnet-version: '7.0'
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -90,7 +90,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0
+          dotnet-version: '7.0'
       - name: Download Artifact
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
It's better to use 7.0.x for feature bug and security fixes.

> The dotnet-version input supports following syntax:
>
> * A.B.C (e.g 6.0.400, 7.0.100-preview.7.22377.5) - installs exact version of .NET SDK
> * A.B or A.B.x (e.g. 3.1, 3.1.x) - installs the latest patch version of .NET SDK on the channel 3.1, including prerelease versions (preview, rc)
> * A or A.x (e.g. 3, 3.x) - installs the latest minor version of the specified major tag, including prerelease versions (preview, rc)


source: https://github.com/actions/setup-dotnet#supported-version-syntax