### PR TITLE
Add Maestro card numbers for Belgium

### DIFF
--- a/src/DEdge.Cardidy/Model/Cards.cs
+++ b/src/DEdge.Cardidy/Model/Cards.cs
@@ -56,7 +56,7 @@ internal record Maestro : ALuhnCard
 {
     public Maestro() : base(CardType.Maestro, new[] { 5018, 5020, 5038, 5893, 6304, 6759, 6761, 6762, 6763,
     //https://www.freebinchecker.com/belgium_maestro-bin-list-brand?hl=fr
-    6703,6799,6775,6711,6708,6705,6709,6390,6792,6706
+    6703,6799,6775,6711,6708,6705,6709,6390,6792,6706,6704
     }, From12To19) { }
 }
 

--- a/src/DEdge.Cardidy/Model/Cards.cs
+++ b/src/DEdge.Cardidy/Model/Cards.cs
@@ -54,7 +54,10 @@ internal record MaestroUk : ALuhnCard
 
 internal record Maestro : ALuhnCard
 {
-    public Maestro() : base(CardType.Maestro, new[] { 5018, 5020, 5038, 5893, 6304, 6759, 6761, 6762, 6763 }, From12To19) { }
+    public Maestro() : base(CardType.Maestro, new[] { 5018, 5020, 5038, 5893, 6304, 6759, 6761, 6762, 6763,
+    //https://www.freebinchecker.com/belgium_maestro-bin-list-brand?hl=fr
+    6703,6799,6775,6711,6708,6705,6709,6390,6792,6706
+    }, From12To19) { }
 }
 
 internal record MasterCard : ALuhnCard

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -167,10 +167,10 @@ public class IdentifyTests
     [TestCase("6384960368309025--", ExpectedResult = CardType.InstaPayment)]
     public CardType ShouldIdentifyAsInstaPayment(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: true, ignoreNoise: true).First();
 
-    [TestCase("6709123456789876", ExpectedResult = new[] { CardType.Laser, CardType.GPN })]
+    [TestCase("6709123456789876", ExpectedResult = new[] { CardType.Maestro, CardType.Laser, CardType.GPN })]
     [TestCase("6771123456789876", ExpectedResult = new[] { CardType.Laser, CardType.GPN })]
     [TestCase("6304000004583145", ExpectedResult = new[] { CardType.Maestro, CardType.Laser, CardType.GPN })]
-    [TestCase("6706710000901089", ExpectedResult = new[] { CardType.Laser, CardType.GPN })]
+    [TestCase("6706710000901089", ExpectedResult = new[] { CardType.Maestro, CardType.Laser, CardType.GPN })]
     public IEnumerable<CardType> ShouldIdentifyAsLaser(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true).ToArray();
 
     [TestCase("4903670912340031", ExpectedResult = new[] { CardType.Visa, CardType.Switch })]

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -55,6 +55,8 @@ public class IdentifyTests
     [TestCase("5018-7100009012345", ExpectedResult = CardType.Maestro)]
     [TestCase("5018-71000090123456", ExpectedResult = CardType.Maestro)]
     [TestCase("5018-710000901234567", ExpectedResult = CardType.Maestro)]
+    [TestCase("67044- 4444444449", ExpectedResult = CardType.Maestro)]
+    [TestCase("670300- 0000000000003", ExpectedResult = CardType.Maestro)]
     public CardType ShouldIdentifyAsMaestro(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true).First();
 
     [TestCase("676770-0000901089", ExpectedResult = CardType.MaestroUk)]

--- a/src/Tests/IdentifyTests.cs
+++ b/src/Tests/IdentifyTests.cs
@@ -55,8 +55,8 @@ public class IdentifyTests
     [TestCase("5018-7100009012345", ExpectedResult = CardType.Maestro)]
     [TestCase("5018-71000090123456", ExpectedResult = CardType.Maestro)]
     [TestCase("5018-710000901234567", ExpectedResult = CardType.Maestro)]
-    [TestCase("67044- 4444444449", ExpectedResult = CardType.Maestro)]
-    [TestCase("670300- 0000000000003", ExpectedResult = CardType.Maestro)]
+    [TestCase("6704-44444444449", ExpectedResult = CardType.Maestro)]
+    [TestCase("6703-000000000000003", ExpectedResult = CardType.Maestro)]
     public CardType ShouldIdentifyAsMaestro(string cardNumber) => Cardidy.Identify(cardNumber, useCheck: false, ignoreNoise: true).First();
 
     [TestCase("676770-0000901089", ExpectedResult = CardType.MaestroUk)]


### PR DESCRIPTION
We noticed that Maestro  is not completely managed in Cardidy.
We need to add support to maestro in order to test Bancontact implementation for D-EDGE PAY:
https://docs.adyen.com/payment-methods/bancontact/bancontact-card/api-only/#test-and-go-live

Wikipedia does not contain all Maestro ranges, but we can consider that they are missing since they exist on freebinchecker:
https://www.freebinchecker.com/belgium_maestro-bin-list-brand?hl=fr